### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.23.x]
+        go-version: [1.24.x, 1.25.x]
         os: [ubuntu-latest] # macos disabled for now because of disk space issues.
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## Updates

- Go test versions: 1.24.x, 1.25.x
- GitHub Actions: updated to pinned hashes

---
Created by mygithelper